### PR TITLE
Add support for -h flag

### DIFF
--- a/src/controllers/click_controller.py
+++ b/src/controllers/click_controller.py
@@ -1,10 +1,9 @@
 import click
 from src import __version__
-
+from .helpers import CustomCommand
 
 class ClickController:
-
-    @click.command()
+    @click.command(cls=CustomCommand)
     @click.option("-v", "--version", is_flag=True, help="Show the version and exit.")
     @click.pass_context
     def hello(ctx, version):

--- a/src/controllers/helpers/__init__.py
+++ b/src/controllers/helpers/__init__.py
@@ -1,0 +1,1 @@
+from .custom_command import CustomCommand

--- a/src/controllers/helpers/custom_command.py
+++ b/src/controllers/helpers/custom_command.py
@@ -1,0 +1,13 @@
+import click
+
+class CustomCommand(click.Command):
+    def parse_args(self, ctx, args):
+        if "-h" in args:
+            args = ["--help" if arg == "-h" else arg for arg in args]
+        return super().parse_args(ctx, args)
+
+    def get_help_option(self, ctx):
+        # Override to add `-h` as an alias for `--help` in the help message
+        help_option = super().get_help_option(ctx)
+        help_option.opts.append("-h")  # Add `-h` to the help flag options
+        return help_option


### PR DESCRIPTION
- Extended `Command` class from `click` package to allow short version of --help flag.
- Used this extended class in my controller command.