### PR TITLE
Added support for -o and --output flags

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,9 +1,6 @@
-import os
-import getpass
 from src.controllers import ClickController
 
 controller = ClickController()
 
 if __name__ == "__main__":
-    os.environ["OPENAI_API_KEY"] = getpass.getpass('Open AI API key:')
-    controller.copy_files()
+    controller.infuse_files()


### PR DESCRIPTION
- Added support for -o and --output flags for the user to be able to overwrite default output files directory
- Made sure to catch errors when files do not contain source code under correct `except` block
- Moved the API key prompt inside of handler