### PR TITLE
Docs/readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,34 +28,24 @@ cd infusion
 
 After that, you will have to set up a virtual environment and install all the dependencies. 
 
-If you are on Windows, use **PowerShell** to set up virtual environemnt using the command:
+If you are on **Windows**, use **PowerShell** to set up virtual environemnt using the command:
 ```powershell
 ./setup/setup.ps1
 ```
 
-If you are on Mac / Linux, use the following command:
+If you are on **Mac / Linux**, use the following command:
 ```bash
 ./setup/setup.sh
 ```
 
-After you are done setting up virtual environment, you need to open it. You do this using the following command:
+After you are done setting up virtual environment, you can use the Infusion tool by running:
 ```bash
-pipenv bash
-```
-
-Once you are in the virtual environment, you can start using the **Infusion** utility. Read [this](#usage) section for usage. 
-
-Once you are done using the utility, you can exit the virtual environment by running:
-```bash
-exit
+pipenv run infsue [OPTIONS] [FILE_PATHS]...
 ```
 
 ## Usage
 
-To use Infusion, run the following command, replacing FILE_PATHS with the paths to the source code files you want to process:
-```bash
-python -m src.app [OPTIONS] [FILE_PATHS]
-```
+To use Infusion, run the following command, replacing FILE_PATHS with the paths to the source code files you want to process.
 
 Process a single file:
 ```bash
@@ -70,6 +60,11 @@ python -m src.app ./path/to/source.py --output my_output_folder
 Process multiple files:
 ```bash
 python -m src.app ./file1.js ./file2.py
+```
+
+Process multiple files without specifying each one of them:
+```bash
+python -m src.app ./folder/*
 ```
 
 Process multiple files and specify an output folder:

--- a/src/controllers/click_controller.py
+++ b/src/controllers/click_controller.py
@@ -39,18 +39,13 @@ class ClickController:
     @click.pass_context
     def infuse_files(ctx, file_paths, version, output_dir, token_usage):
         """
-        Processes multiple source code files to add documentation using a language model.
+        Infusion is a command-line tool designed to help you generate documentation for your source code using advanced language models.
+        You provide file paths in your current directory, LLM modifies them to include documentation, and inserts them into the output folder.
 
-        Args:
-            ctx (Context): Click context object for command execution.
-            file_paths (tuple): Paths to the source code files to be infused.
-            version (bool): If True, display the version of the tool.
-            output_dir (str): Directory to save the infused files. Defaults to 'fusion_output'.
-            token_usage (bool): If True, display token usage statistics.
-
-        Returns:
-            None
+        You provide multiple FILE_PATHS by separating them with spaces. Relative paths will be relative to the directory, from which you are calling this tool.
+        Absolute paths are also supported.
         """
+        
         if version:
             ClickController.__print_version(ctx)
 

--- a/src/controllers/helpers/custom_command.py
+++ b/src/controllers/helpers/custom_command.py
@@ -30,3 +30,11 @@ class CustomCommand(click.Command):
             # Override the help text for the `-h` and `--help` options
             help_option.help = "Show the help message."
         return help_option
+
+    def format_usage(self, ctx, formatter):
+        """
+        Customizes the usage message displayed in the help output.
+        """
+        usage_message = f"Usage: pipenv run infuse [OPTIONS] [FILE_PATHS]..."
+        formatter.write(usage_message)
+        formatter.write("\n")


### PR DESCRIPTION
- Modified `CustomCommand` class to show `pipenv` startup script instead of `python -m` command.
- Modified README file to show `pipenv` startup script instead of `python -m` command.