### PR TITLE
Feature/stdout output

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Process multiple files without specifying every single one of them:
 pipenv run infsue ./folder/*
 ```
 
-Process multiple files and specify an output folder:
+Process multiple files and specify an output folder to save files to instead of printing them to stdout:
 ```bash
 pipenv run infsue ./file1.js ./file2.py --output my_output_folder
 ```
@@ -108,7 +108,7 @@ Folder structure after Infusion executed:
 
 ## Options
 - `-v, --version`: Show the current version of the tool and exit.
-- `-o, --output`: Specify the output folder for the processed files. If not provided, the default folder is **fusion_output** in the current directory.
+- `-o, --output`: Specify an output folder for files with generated documentation. If not provided, the output will be shown in stdout, and won't be saved to any file.
 - `-h, --help`: Show the help message with usage details and exit.
 - `-u, --token-usage`: Show the number of tokens that were sent in the prompt and returned in the response.
 

--- a/src/controllers/click_controller.py
+++ b/src/controllers/click_controller.py
@@ -27,7 +27,7 @@ class ClickController:
         "--output",
         "output_dir",
         type=click.Path(),
-        help="Specify an output folder. If not provided, the output folder will be `fusion_output` in the current directory.",
+        help="Specify an output folder for files with generated documentation. If not provided, the output will be shown in stdout, and won't be saved to any file.",
     )
     @click.option(
         "-u",

--- a/src/services/logging/click_logging_service.py
+++ b/src/services/logging/click_logging_service.py
@@ -7,17 +7,18 @@ class ClickLoggingService:
     It allows logging informational, error, and debug messages with styled output.
     """
 
-    def log_info(self, message):
+    def log_info(self, message, color = "blue"):
         """
         Logs an informational message to the console with blue text. This message is printed to stdout.
 
         Args:
             message (str): The informational message to log.
+            color (str): The color used when printing a message. By default it's 'blue'.
 
         Returns:
             None
         """
-        click.echo(click.style(message, fg="blue", bold=True))
+        click.echo(click.style(message, fg=color, bold=True))
 
     def log_error(self, message):
         """


### PR DESCRIPTION
- Instead of saving files to the output folder by default, printing them to stdout instead.
- If stdout is specified, save generated files inside of output folder instead of printing them to the console.
- Updated help command and README file to reflect new information about output flag.